### PR TITLE
[INLONG-11916][SDK] Python SDK supports installation to the …

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
@@ -50,14 +50,37 @@ Go to the `dataproxy-sdk-python` root directory, and run the following commands:
 chmod +x ./build.sh
 ./build.sh
 ```
-When the .so file is generated, you will see the following message, you can choose to enter the target directory for the .so files. By default, the .so file will be copied to the system python site-packages directory:
 
-```txt
-Your system's Python site-packages directory is: xxx/xxx
-Enter the target directory for the .so files (Press Enter to use the default site-packages directory):
+When the .so file is generated, the script will automatically detect if you are in a virtual environment. Based on the detection result, you'll see one of the following prompts:
+
+#### In a virtual environment:
+```
+Detected virtual environment: /path/to/your/venv
+Virtual environment site-packages: /path/to/your/venv/lib/pythonX.Y/site-packages
+Your system's existing Python site-packages directories are:
+  /usr/lib/pythonX.Y/site-packages
+  ...
+
+Please select the installation location for the .so files:
+1. Virtual environment site-packages directory: /path/to/your/venv/lib/pythonX.Y/site-packages
+2. System site-packages directories
+3. Custom directory
+Enter your choice (1-3):
 ```
 
-After the build process finished, you can import the package (`import inlong_dataproxy`) in your python project to use InLong dataproxy.
+#### Without a virtual environment:
+```
+Your system's existing Python site-packages directories are:
+  /usr/lib/pythonX.Y/site-packages
+  ...
+
+Please select the installation location for the .so files:
+1. System site-packages directories
+2. Custom directory
+Enter your choice (1-2):
+```
+
+Choose the appropriate option based on your needs. After the build process finishes, you can import the package (`import inlong_dataproxy`) in your Python project to use InLong dataproxy.
 
 > **Note**: When the C++ SDK or the version of Python you're using is updated, you'll need to rebuild it by the above steps.
 
@@ -124,6 +147,22 @@ Follow these steps to use the DataProxy Python SDK:
    ```
 
 4. **Function return values**: The functions mentioned above return 0 if they are successful, and a non-zero value indicates failure. Make sure to check the return values to ensure proper execution.
+
+## Using in Virtual Environments
+
+The SDK now fully supports installation and usage within Python virtual environments:
+
+1. **Automatic Detection**: The build script automatically detects when it's being run from within a virtual environment (venv, virtualenv, etc.).
+
+2. **Installation Options**: During installation, you can choose to:
+   - Install to the virtual environment's site-packages directory (recommended when using a virtual environment)
+   - Install to the system-wide site-packages directories
+   - Specify a custom installation directory
+
+3. **Best Practices**:
+   - When working within a virtual environment, choose option 1 to install to the virtual environment's site-packages
+   - This ensures that the SDK is available to your virtual environment without affecting the system Python installation
+   - For system-wide availability, choose option 2
 
 ## Demo
 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/test_venv_detection.py
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/test_venv_detection.py
@@ -1,0 +1,109 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import os
+import sys
+import site
+import sysconfig
+
+def main():
+    """
+    Test script to detect virtual environments and print related path information
+    """
+    print("Python Virtual Environment Detection Tool")
+    print("========================================")
+    print(f"Python version: {sys.version}")
+    print(f"Python interpreter path: {sys.executable}")
+
+    # Check VIRTUAL_ENV environment variable
+    virtual_env = os.environ.get('VIRTUAL_ENV')
+    if virtual_env:
+        print(f"\nDetected virtual environment variable: VIRTUAL_ENV={virtual_env}")
+    else:
+        print("\nVIRTUAL_ENV environment variable not detected")
+        
+        # Check if sys.executable path contains virtual environment markers
+        if any(venv_marker in sys.executable for venv_marker in ['/venv/', '/virtualenv/', '/.virtualenvs/']):
+            virtual_env = os.path.dirname(os.path.dirname(sys.executable))
+            print(f"Virtual environment detected from interpreter path: {virtual_env}")
+        else:
+            print("No virtual environment detected from interpreter path")
+
+    # Get site-packages directories
+    print("\nPaths returned by site.getsitepackages():")
+    try:
+        site_packages = site.getsitepackages()
+        for i, path in enumerate(site_packages):
+            print(f"  {i+1}. {path}")
+    except AttributeError:
+        print("  site.getsitepackages() not available")
+    
+    # Using sysconfig
+    print("\nPaths returned by sysconfig module:")
+    sysconfig_paths = sysconfig.get_paths()
+    platlib_path = sysconfig_paths.get('platlib')  # Platform-specific library directory
+    purelib_path = sysconfig_paths.get('purelib')  # Platform-independent library directory
+    
+    print(f"  platlib (platform-specific packages): {platlib_path}")
+    print(f"  purelib (platform-independent packages): {purelib_path}")
+    
+    print("\nPath returned by site.getusersitepackages():")
+    try:
+        user_site = site.getusersitepackages()
+        print(f"  {user_site}")
+    except AttributeError:
+        print("  site.getusersitepackages() not available")
+    
+    # Summary of virtual environment detection
+    print("\nSummary:")
+    if virtual_env:
+        print(f"Currently running in a virtual environment: {virtual_env}")
+        # Check if site-packages directory is in the virtual environment
+        venv_site_detected = False
+        site_packages_path = ""
+        
+        # Check path from sysconfig
+        if platlib_path and virtual_env in platlib_path:
+            venv_site_detected = True
+            site_packages_path = platlib_path
+        elif purelib_path and virtual_env in purelib_path:
+            venv_site_detected = True
+            site_packages_path = purelib_path
+        
+        # Check paths from site.getsitepackages()
+        if not venv_site_detected and 'site_packages' in locals():
+            for path in site_packages:
+                if virtual_env in path:
+                    venv_site_detected = True
+                    site_packages_path = path
+                    break
+        
+        if venv_site_detected:
+            print(f"Virtual environment site-packages directory: {site_packages_path}")
+        else:
+            print("Could not determine virtual environment's site-packages directory")
+            # Try to guess the path based on convention
+            guess_path = os.path.join(virtual_env, 'lib', f'python{sys.version_info.major}.{sys.version_info.minor}', 'site-packages')
+            if os.path.exists(guess_path):
+                print(f"Guessed virtual environment site-packages directory (based on convention): {guess_path}")
+    else:
+        print("Not running in a virtual environment, using system Python")
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
…site packages directory in virtual environments

<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11916

### Motivation
Currently, the installation script of the InLong Python SDK in the virtual environment (such as venv, virtualenv) cannot be automatically detected and installed to the site-packages directory of the virtual environment, resulting in users having to manually enter the path and having a poor experience. It is hoped that through automatic detection and friendly prompts, the installation experience in the virtual environment can be enhanced and the probability of user errors can be reduced.
<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications
- Optimize the build.sh script to automatically detect whether it is currently in a virtual environment and obtain the site-packages path of the virtual environment.
- Dynamically generate available installation options (virtual environment, system, or custom directory) and guide users to make their choices.
- Enhance robustness: If no site-packages directory is detected, force users to enter custom directories to avoid silent failure.
- Encapsulate the file copy logic to enhance code readability and maintainability.
- Update the README document to explain the installation process and precautions in the virtual environment.
- Add test script test_venv_detection.py.Test script to detect virtual environments and print related path information.
<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:
  - *Tested in the venv virtual environment, it can automatically detect and install to the virtual environment site-packages.*
  - *Tested in the virtualenv virtual environment, it can automatically detect and install to the virtual environment site-packages.*
  - *Tested in a non-virtual environment, it can be correctly installed to the system's site-packages or custom directories.*
  - *The output of the test script test_venv_detection.py is consistent with the actual environment without any warnings.*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)docs
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
